### PR TITLE
Initial release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust - Continuous Integration
 
 on:
   push:
-    branches: [ master ]
+    branches: [ casper-main ]
   pull_request:
-    branches: [ master ]
+    branches: [ casper-main ]
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "wasmi"
+name = "casper-wasmi"
 version = "0.13.2"
 edition = "2021"
-authors = ["Parity Technologies <admin@parity.io>", "Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]
+authors = ["Parity Technologies <admin@parity.io>", "Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>", "Michał Papierski <michal@casperlabs.io>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/paritytech/wasmi"
-documentation = "https://paritytech.github.io/wasmi/"
+repository = "https://github.com/casper-network/casper-wasmi"
+documentation = "https://docs.rs/casper-wasmi/"
 description = "WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
@@ -14,7 +14,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 [dependencies]
 wasmi_core = { version = "0.2.1", path = "core", default-features = false }
 validation = { package = "wasmi-validation", version = "0.5.0", path = "validation", default-features = false }
-casper-wasm = { package = "parity-wasm", default-features = false, git = "https://github.com/casper-network/casper-wasm", branch = "main" }
+casper-wasm = { version = "0.46.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 [dependencies]
 wasmi_core = { version = "0.2.1", path = "core", default-features = false }
 validation = { package = "wasmi-validation", version = "0.5.0", path = "validation", default-features = false }
-parity-wasm = { version = "0.45.0", default-features = false }
+casper-wasm = { package = "parity-wasm", default-features = false, git = "https://github.com/casper-network/casper-wasm", branch = "main" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -33,7 +33,7 @@ default = ["std"]
 # Use `no-default-features` for a `no_std` build.
 std = [
     "wasmi_core/std",
-    "parity-wasm/std",
+    "casper-wasm/std",
     "validation/std",
 ]
 # Enables OS supported virtual memory.
@@ -47,7 +47,7 @@ std = [
 # - By nature this feature requires `region` and the Rust standard library.
 virtual_memory = ["wasmi_core/virtual_memory", "std"]
 
-reduced-stack-buffer = [ "parity-wasm/reduced-stack-buffer" ]
+reduced-stack-buffer = [ "casper-wasm/reduced-stack-buffer" ]
 
 [workspace]
 members = ["validation", "core", "wasmi_v1", "cli"]

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 |:----------------------:|:--------------------:|:----------------:|:--------------------:|
 | [![ci][1]][2]          | [![codecov][5]][6]   | [![docs][9]][10] | [![crates][11]][12]  |
 
-[1]: https://github.com/paritytech/wasmi/workflows/Rust%20-%20Continuous%20Integration/badge.svg?branch=master
-[2]: https://github.com/paritytech/wasmi/actions?query=workflow%3A%22Rust+-+Continuous+Integration%22+branch%3Amaster
-[5]: https://codecov.io/gh/paritytech/wasmi/branch/master/graph/badge.svg
-[6]: https://codecov.io/gh/paritytech/wasmi/branch/master
+[1]: https://github.com/casper-network/casper-wasmi/workflows/Rust%20-%20Continuous%20Integration/badge.svg?branch=master
+[2]: https://github.com/casper-network/casper-wasmi/actions?query=workflow%3A%22Rust+-+Continuous+Integration%22+branch%3Amaster
+[5]: https://codecov.io/gh/casper-network/casper-wasmi/branch/master/graph/badge.svg
+[6]: https://codecov.io/gh/casper-network/casper-wasmi/branch/master
 [9]: https://docs.rs/wasmi/badge.svg
 [10]: https://docs.rs/wasmi
 [11]: https://img.shields.io/crates/v/wasmi.svg
@@ -15,11 +15,13 @@
 [license-mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license-apache-badge]: https://img.shields.io/badge/license-APACHE-orange.svg
 
-# `wasmi`- WebAssembly (Wasm) Interpreter
+# `casper-wasmi`- WebAssembly (Wasm) Interpreter
 
-`wasmi` was conceived as a component of [parity-ethereum](https://github.com/paritytech/parity-ethereum) (ethereum-like contracts in wasm) and [substrate](https://github.com/paritytech/substrate). These projects are related to blockchain and require a high degree of correctness. The project is not trying to be involved in any implementation of any work-in-progress Wasm proposals. Instead the project tries to be as close as possible to the specification, therefore avoiding features that are not directly supported by the specification.
+`wasmi` was originally conceived as a component of [parity-ethereum](https://github.com/paritytech/parity-ethereum) (ethereum-like contracts in wasm) and [substrate](https://github.com/paritytech/substrate). These projects are related to blockchain and require a high degree of correctness. The project is not trying to be involved in any implementation of any work-in-progress Wasm proposals. Instead the project tries to be as close as possible to the specification, therefore avoiding features that are not directly supported by the specification.
 
 With all that said `wasmi` should be a good option for initial prototyping and there shouldn't be a problem migrating from `wasmi` to another specification compliant execution engine later on.
+
+The crate `casper-wasmi` is a fork of a wasmi project with additional fixes and security hardening.
 
 # Distinct Features
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -10,10 +10,10 @@ use self::bench::{
     load_wasm_from_file,
     wat2wasm,
 };
+use casper_wasmi as v0;
+use casper_wasmi::{RuntimeValue as Value, Trap};
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use std::{slice, time::Duration};
-use wasmi as v0;
-use wasmi::{RuntimeValue as Value, Trap};
 use wasmi_v1 as v1;
 
 const WASM_KERNEL: &str =

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin.freyler@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "../README.md"
-repository = "https://github.com/paritytech/wasmi"
-documentation = "https://paritytech.github.io/wasmi/"
+repository = "https://github.com/casper-network/casper-wasmi"
+documentation = "https://docs.rs/casper-wasmi/"
 description = "WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,14 +1,14 @@
 use anyhow::{anyhow, bail, Result};
-use clap::Parser;
-use core::fmt::Write;
-use std::fs;
-use wasmi::{
+use casper_wasmi::{
     core::{Value, ValueType, F32, F64},
     ExportItemKind,
     Func,
     FuncType,
     Store,
 };
+use clap::Parser;
+use core::fmt::Write;
+use std::fs;
 use wasmi_v1 as wasmi;
 
 /// Simple program to greet a person

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0"
 readme = "../README.md"
-repository = "https://github.com/paritytech/wasmi"
-documentation = "https://docs.rs/wasmi_core"
+repository = "https://github.com/casper-network/casper-wasmi"
+documentation = "https://docs.rs/casper_wasmi_core/"
 description = "Core abstractions and primitives for the wasmi WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 

--- a/examples/interpret.rs
+++ b/examples/interpret.rs
@@ -1,9 +1,9 @@
 // In this example we execute a contract funciton exported as "_call"
 
-extern crate wasmi;
+extern crate casper_wasmi;
 
+use casper_wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, RuntimeValue};
 use std::{env::args, fs::File};
-use wasmi::{ImportsBuilder, Module, ModuleInstance, NopExternals, RuntimeValue};
 
 fn load_from_file(filename: &str) -> Module {
     use std::io::prelude::*;

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -1,10 +1,10 @@
 extern crate casper_wasm;
-extern crate wasmi;
+extern crate casper_wasmi;
 
 use std::env::args;
 
 use casper_wasm::elements::{External, FunctionType, Internal, Module, Type, ValueType};
-use wasmi::{ImportsBuilder, ModuleInstance, NopExternals, RuntimeValue};
+use casper_wasmi::{ImportsBuilder, ModuleInstance, NopExternals, RuntimeValue};
 
 fn main() {
     let args: Vec<_> = args().collect();
@@ -98,7 +98,8 @@ fn main() {
             .collect::<Vec<RuntimeValue>>()
     };
 
-    let loaded_module = wasmi::Module::from_casper_wasm_module(module).expect("Module to be valid");
+    let loaded_module =
+        casper_wasmi::Module::from_casper_wasm_module(module).expect("Module to be valid");
 
     // Intialize deserialized module. It adds module into It expects 3 parameters:
     // - a name for the module

--- a/examples/invoke.rs
+++ b/examples/invoke.rs
@@ -1,9 +1,9 @@
-extern crate parity_wasm;
+extern crate casper_wasm;
 extern crate wasmi;
 
 use std::env::args;
 
-use parity_wasm::elements::{External, FunctionType, Internal, Module, Type, ValueType};
+use casper_wasm::elements::{External, FunctionType, Internal, Module, Type, ValueType};
 use wasmi::{ImportsBuilder, ModuleInstance, NopExternals, RuntimeValue};
 
 fn main() {
@@ -98,7 +98,7 @@ fn main() {
             .collect::<Vec<RuntimeValue>>()
     };
 
-    let loaded_module = wasmi::Module::from_parity_wasm_module(module).expect("Module to be valid");
+    let loaded_module = wasmi::Module::from_casper_wasm_module(module).expect("Module to be valid");
 
     // Intialize deserialized module. It adds module into It expects 3 parameters:
     // - a name for the module
@@ -119,11 +119,11 @@ fn main() {
 
 #[cfg(feature = "std")]
 fn load_module(file: &str) -> Module {
-    parity_wasm::deserialize_file(file).expect("File to be deserialized")
+    casper_wasm::deserialize_file(file).expect("File to be deserialized")
 }
 
 #[cfg(not(feature = "std"))]
 fn load_module(file: &str) -> Module {
     let mut buf = std::fs::read(file).expect("Read file");
-    parity_wasm::deserialize_buffer(&mut buf).expect("Deserialize module")
+    casper_wasm::deserialize_buffer(&mut buf).expect("Deserialize module")
 }

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -1,4 +1,4 @@
-extern crate parity_wasm;
+extern crate casper_wasm;
 extern crate wasmi;
 
 use std::{env, fmt, fs::File};

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -1,8 +1,7 @@
 extern crate casper_wasm;
-extern crate wasmi;
+extern crate casper_wasmi;
 
-use std::{env, fmt, fs::File};
-use wasmi::{
+use casper_wasmi::{
     Error as InterpreterError,
     Externals,
     FuncInstance,
@@ -18,6 +17,7 @@ use wasmi::{
     Trap,
     ValueType,
 };
+use std::{env, fmt, fs::File};
 
 #[derive(Debug)]
 pub enum Error {
@@ -202,7 +202,7 @@ fn instantiate(path: &str) -> Result<ModuleRef, Error> {
         let mut file = File::open(path).unwrap();
         let mut wasm_buf = Vec::new();
         file.read_to_end(&mut wasm_buf).unwrap();
-        wasmi::Module::from_buffer(&wasm_buf)?
+        casper_wasmi::Module::from_buffer(&wasm_buf)?
     };
 
     let mut imports = ImportsBuilder::new();

--- a/fuzz/fuzz_targets/load.rs
+++ b/fuzz/fuzz_targets/load.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #[macro_use]
 extern crate libfuzzer_sys;
-extern crate wasmi;
+extern crate casper_wasmi;
 
 fuzz_target!(|data: &[u8]| {
 	// Just check if loading some arbitrary buffer doesn't panic.

--- a/fuzz/fuzz_targets/load_spec.rs
+++ b/fuzz/fuzz_targets/load_spec.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate wabt;
-extern crate wasmi;
+extern crate casper_wasmi;
 extern crate tempdir;
 
 use std::fs::File;

--- a/fuzz/fuzz_targets/load_wabt.rs
+++ b/fuzz/fuzz_targets/load_wabt.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 extern crate wabt;
-extern crate wasmi;
+extern crate casper_wasmi;
 
 fuzz_target!(|data: &[u8]| {
 	let wasmi_result = wasmi::Module::from_buffer(data);

--- a/fuzz/fuzz_targets/load_wasmparser.rs
+++ b/fuzz/fuzz_targets/load_wasmparser.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #[macro_use]
 extern crate libfuzzer_sys;
-extern crate wasmi;
+extern crate casper_wasmi;
 extern crate wasmparser;
 
 use wasmparser::WasmDecoder;

--- a/hfuzz/src/main.rs
+++ b/hfuzz/src/main.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate honggfuzz;
 
 extern crate wabt;
-extern crate wasmi;
+extern crate casper_wasmi;
 extern crate tempdir;
 
 use std::fs::File;

--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -1,10 +1,9 @@
 //! Handy utility to test whether the given module deserializes,
 //! validates and instantiates successfully.
 
-extern crate wasmi;
+extern crate casper_wasmi;
 
-use std::{env::args, fs::File};
-use wasmi::{
+use casper_wasmi::{
     memory_units::*,
     Error,
     FuncInstance,
@@ -26,6 +25,7 @@ use wasmi::{
     TableInstance,
     TableRef,
 };
+use std::{env::args, fs::File};
 
 fn load_from_file(filename: &str) -> Module {
     use std::io::prelude::*;

--- a/src/func.rs
+++ b/src/func.rs
@@ -13,8 +13,8 @@ use alloc::{
     rc::{Rc, Weak},
     vec::Vec,
 };
+use casper_wasm::elements::Local;
 use core::fmt;
-use parity_wasm::elements::Local;
 
 /// Reference to a function (See [`FuncInstance`] for details).
 ///

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,7 +1,7 @@
 use crate::{pwasm::PwasmCompat, Error, RuntimeValue, ValueType};
 use alloc::rc::Rc;
+use casper_wasm::elements::ValueType as EValueType;
 use core::cell::Cell;
-use parity_wasm::elements::ValueType as EValueType;
 
 /// Reference to a global variable (See [`GlobalInstance`] for details).
 ///

--- a/src/host.rs
+++ b/src/host.rs
@@ -73,7 +73,7 @@ impl<'a> RuntimeArgs<'a> {
 /// # Examples
 ///
 /// ```rust
-/// use wasmi::{
+/// use casper_wasmi::{
 ///     Externals, RuntimeValue, RuntimeArgs, Error, ModuleImportResolver,
 ///     FuncRef, ValueType, Signature, FuncInstance, Trap,
 /// };

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -81,12 +81,12 @@ pub trait ImportResolver {
 /// # Examples
 ///
 /// ```rust
-/// use wasmi::{ModuleInstance, ImportsBuilder};
+/// use casper_wasmi::{ModuleInstance, ImportsBuilder};
 /// #
 /// # struct EnvModuleResolver;
-/// # impl ::wasmi::ModuleImportResolver for EnvModuleResolver { }
-/// # fn func() -> Result<(), ::wasmi::Error> {
-/// # let module = wasmi::Module::from_buffer(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]).unwrap();
+/// # impl ::casper_wasmi::ModuleImportResolver for EnvModuleResolver { }
+/// # fn func() -> Result<(), ::casper_wasmi::Error> {
+/// # let module = casper_wasmi::Module::from_buffer(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]).unwrap();
 /// # let other_instance = ModuleInstance::new(&module, &ImportsBuilder::default())?.assert_no_start();
 ///
 /// let imports = ImportsBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,10 @@
 //! # Examples
 //!
 //! ```rust
-//! extern crate wasmi;
+//! extern crate casper_wasmi;
 //! extern crate wat;
 //!
-//! use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
+//! use casper_wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
 //!
 //! fn main() {
 //!     // Parse WAT (WebAssembly Text format) into wasm bytecode.
@@ -68,7 +68,7 @@
 //!         .expect("failed to parse wat");
 //!
 //!     // Load wasm binary and prepare it for instantiation.
-//!     let module = wasmi::Module::from_buffer(&wasm_binary)
+//!     let module = casper_wasmi::Module::from_buffer(&wasm_binary)
 //!         .expect("failed to load wasm");
 //!
 //!     // Instantiate a module with empty imports and
@@ -333,7 +333,7 @@ impl Module {
     ///
     /// ```rust
     /// extern crate casper_wasm;
-    /// extern crate wasmi;
+    /// extern crate casper_wasmi;
     ///
     /// use casper_wasm::builder;
     /// use casper_wasm::elements;
@@ -347,7 +347,7 @@ impl Module {
     ///             .build()
     ///         .build();
     ///
-    ///     let module = wasmi::Module::from_casper_wasm_module(parity_module)
+    ///     let module = casper_wasmi::Module::from_casper_wasm_module(parity_module)
     ///         .expect("casper-wasm builder generated invalid module!");
     ///
     ///     // Instantiate `module`, etc...
@@ -371,7 +371,7 @@ impl Module {
     ///
     /// ```rust
     /// extern crate casper_wasm;
-    /// extern crate wasmi;
+    /// extern crate casper_wasmi;
     ///
     /// use casper_wasm::builder;
     /// use casper_wasm::elements;
@@ -385,7 +385,7 @@ impl Module {
     ///             .build()
     ///         .build();
     ///
-    ///     let module = wasmi::Module::from_casper_wasm_module(parity_module)
+    ///     let module = casper_wasmi::Module::from_casper_wasm_module(parity_module)
     ///         .expect("casper-wasm builder generated invalid module!");
     ///
     ///     // Instantiate `module`, etc...
@@ -406,7 +406,7 @@ impl Module {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate wasmi;
+    /// # extern crate casper_wasmi;
     /// # extern crate wat;
     ///
     /// let wasm_binary: Vec<u8> =
@@ -422,7 +422,7 @@ impl Module {
     ///     .expect("failed to parse wat");
     ///
     /// // Load wasm binary and prepare it for instantiation.
-    /// let module = wasmi::Module::from_buffer(&wasm_binary).expect("Parsing failed");
+    /// let module = casper_wasmi::Module::from_buffer(&wasm_binary).expect("Parsing failed");
     /// assert!(module.deny_floating_point().is_ok());
     ///
     /// let wasm_binary: Vec<u8> =
@@ -437,7 +437,7 @@ impl Module {
     ///     )
     ///     .expect("failed to parse wat");
     ///
-    /// let module = wasmi::Module::from_buffer(&wasm_binary).expect("Parsing failed");
+    /// let module = casper_wasmi::Module::from_buffer(&wasm_binary).expect("Parsing failed");
     /// assert!(module.deny_floating_point().is_err());
     ///
     /// let wasm_binary: Vec<u8> =
@@ -450,7 +450,7 @@ impl Module {
     ///     )
     ///     .expect("failed to parse wat");
     ///
-    /// let module = wasmi::Module::from_buffer(&wasm_binary).expect("Parsing failed");
+    /// let module = casper_wasmi::Module::from_buffer(&wasm_binary).expect("Parsing failed");
     /// assert!(module.deny_floating_point().is_err());
     /// ```
     pub fn deny_floating_point(&self) -> Result<(), Error> {
@@ -469,11 +469,11 @@ impl Module {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate wasmi;
+    /// extern crate casper_wasmi;
     ///
     /// fn main() {
     ///     let module =
-    ///         wasmi::Module::from_buffer(
+    ///         casper_wasmi::Module::from_buffer(
     ///             // Minimal module:
     ///             //   \0asm - magic
     ///             //    0x01 - version (in little-endian)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,8 +376,8 @@ impl Module {
     ///         r#"
     ///         (module
     ///          (func $add (param $lhs i32) (param $rhs i32) (result i32)
-    ///                get_local $lhs
-    ///                get_local $rhs
+    ///                local.get $lhs
+    ///                local.get $rhs
     ///                i32.add))
     ///         "#,
     ///     )
@@ -392,8 +392,8 @@ impl Module {
     ///         r#"
     ///         (module
     ///          (func $add (param $lhs f32) (param $rhs f32) (result f32)
-    ///                get_local $lhs
-    ///                get_local $rhs
+    ///                local.get $lhs
+    ///                local.get $rhs
     ///                f32.add))
     ///         "#,
     ///     )
@@ -407,7 +407,7 @@ impl Module {
     ///         r#"
     ///         (module
     ///          (func $add (param $lhs f32) (param $rhs f32) (result f32)
-    ///                get_local $lhs))
+    ///                local.get $lhs))
     ///         "#,
     ///     )
     ///     .expect("failed to parse wat");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,13 +317,13 @@ pub mod nan_preserving_float {
 /// Deserialized module prepared for instantiation.
 pub struct Module {
     code_map: Vec<isa::Instructions>,
-    module: parity_wasm::elements::Module,
+    module: casper_wasm::elements::Module,
 }
 
 impl Module {
-    /// Create `Module` from `parity_wasm::elements::Module`.
+    /// Create `Module` from `casper_wasm::elements::Module`.
     ///
-    /// This function will load, validate and prepare a `parity_wasm`'s `Module`.
+    /// This function will load, validate and prepare a `casper_wasm`'s `Module`.
     ///
     /// # Errors
     ///
@@ -332,11 +332,11 @@ impl Module {
     /// # Examples
     ///
     /// ```rust
-    /// extern crate parity_wasm;
+    /// extern crate casper_wasm;
     /// extern crate wasmi;
     ///
-    /// use parity_wasm::builder;
-    /// use parity_wasm::elements;
+    /// use casper_wasm::builder;
+    /// use casper_wasm::elements;
     ///
     /// fn main() {
     ///     let parity_module =
@@ -347,13 +347,51 @@ impl Module {
     ///             .build()
     ///         .build();
     ///
-    ///     let module = wasmi::Module::from_parity_wasm_module(parity_module)
-    ///         .expect("parity-wasm builder generated invalid module!");
+    ///     let module = wasmi::Module::from_casper_wasm_module(parity_module)
+    ///         .expect("casper-wasm builder generated invalid module!");
     ///
     ///     // Instantiate `module`, etc...
     /// }
     /// ```
-    pub fn from_parity_wasm_module(module: parity_wasm::elements::Module) -> Result<Module, Error> {
+    #[deprecated(note = "Please use `Module::from_casper_wasm_module` instead")]
+    #[inline]
+    pub fn from_parity_wasm_module(module: casper_wasm::elements::Module) -> Result<Module, Error> {
+        Self::from_casper_wasm_module(module)
+    }
+
+    /// Create `Module` from `casper_wasm::elements::Module`.
+    ///
+    /// This function will load, validate and prepare a `casper_wasm`'s `Module`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if provided `Module` is not valid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate casper_wasm;
+    /// extern crate wasmi;
+    ///
+    /// use casper_wasm::builder;
+    /// use casper_wasm::elements;
+    ///
+    /// fn main() {
+    ///     let parity_module =
+    ///         builder::module()
+    ///             .function()
+    ///                 .signature().with_param(elements::ValueType::I32).build()
+    ///                 .body().build()
+    ///             .build()
+    ///         .build();
+    ///
+    ///     let module = wasmi::Module::from_casper_wasm_module(parity_module)
+    ///         .expect("casper-wasm builder generated invalid module!");
+    ///
+    ///     // Instantiate `module`, etc...
+    /// }
+    /// ```
+    pub fn from_casper_wasm_module(module: casper_wasm::elements::Module) -> Result<Module, Error> {
         let prepare::CompiledModule { code_map, module } = prepare::compile_module(module)?;
 
         Ok(Module { code_map, module })
@@ -446,12 +484,12 @@ impl Module {
     /// }
     /// ```
     pub fn from_buffer<B: AsRef<[u8]>>(buffer: B) -> Result<Module, Error> {
-        let module = parity_wasm::elements::deserialize_buffer(buffer.as_ref())
-            .map_err(|e: parity_wasm::elements::Error| Error::Validation(e.to_string()))?;
-        Module::from_parity_wasm_module(module)
+        let module = casper_wasm::elements::deserialize_buffer(buffer.as_ref())
+            .map_err(|e: casper_wasm::elements::Error| Error::Validation(e.to_string()))?;
+        Module::from_casper_wasm_module(module)
     }
 
-    pub(crate) fn module(&self) -> &parity_wasm::elements::Module {
+    pub(crate) fn module(&self) -> &casper_wasm::elements::Module {
         &self.module
     }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     Error,
 };
 use alloc::{rc::Rc, string::ToString, vec::Vec};
+use casper_wasm::elements::ResizableLimits;
 use core::{
     cell::{Cell, Ref, RefCell, RefMut},
     cmp,
@@ -11,7 +12,6 @@ use core::{
     ops::Range,
     u32,
 };
-use parity_wasm::elements::ResizableLimits;
 
 #[cfg(all(feature = "virtual_memory", target_pointer_width = "64"))]
 #[path = "mmap_bytebuf.rs"]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -181,8 +181,8 @@ impl MemoryInstance {
     /// To convert number of pages to number of bytes you can use the following code:
     ///
     /// ```rust
-    /// use wasmi::MemoryInstance;
-    /// use wasmi::memory_units::*;
+    /// use casper_wasmi::MemoryInstance;
+    /// use casper_wasmi::memory_units::*;
     ///
     /// let memory = MemoryInstance::alloc(Pages(1), None).unwrap();
     /// let byte_size: Bytes = memory.current_size().into();

--- a/src/module.rs
+++ b/src/module.rs
@@ -502,9 +502,9 @@ impl ModuleInstance {
     /// # Examples
     ///
     /// ```rust
-    /// use wasmi::{ModuleInstance, ImportsBuilder, NopExternals};
-    /// # fn func() -> Result<(), ::wasmi::Error> {
-    /// # let module = wasmi::Module::from_buffer(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]).unwrap();
+    /// use casper_wasmi::{ModuleInstance, ImportsBuilder, NopExternals};
+    /// # fn func() -> Result<(), ::casper_wasmi::Error> {
+    /// # let module = casper_wasmi::Module::from_buffer(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]).unwrap();
     ///
     /// // ModuleInstance::new returns instance which `start` function isn't called.
     /// let not_started = ModuleInstance::new(
@@ -522,9 +522,9 @@ impl ModuleInstance {
     /// instantiated module without calling `start` function.
     ///
     /// ```rust
-    /// use wasmi::{ModuleInstance, ImportsBuilder, NopExternals};
-    /// # fn func() -> Result<(), ::wasmi::Error> {
-    /// # let module = wasmi::Module::from_buffer(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]).unwrap();
+    /// use casper_wasmi::{ModuleInstance, ImportsBuilder, NopExternals};
+    /// # fn func() -> Result<(), ::casper_wasmi::Error> {
+    /// # let module = casper_wasmi::Module::from_buffer(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]).unwrap();
     ///
     /// // This will panic if the module actually contain `start` function.
     /// let not_started = ModuleInstance::new(
@@ -604,9 +604,9 @@ impl ModuleInstance {
     /// Invoke a function that takes two numbers and returns sum of them.
     ///
     /// ```rust
-    /// # extern crate wasmi;
+    /// # extern crate casper_wasmi;
     /// # extern crate wat;
-    /// # use wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
+    /// # use casper_wasmi::{ModuleInstance, ImportsBuilder, NopExternals, RuntimeValue};
     /// # fn main() {
     /// # let wasm_binary: Vec<u8> = wat::parse_str(
     /// #   r#"
@@ -619,7 +619,7 @@ impl ModuleInstance {
     /// #   )
     /// #   "#,
     /// # ).expect("failed to parse wat");
-    /// # let module = wasmi::Module::from_buffer(&wasm_binary).expect("failed to load wasm");
+    /// # let module = casper_wasmi::Module::from_buffer(&wasm_binary).expect("failed to load wasm");
     /// # let instance = ModuleInstance::new(
     /// # &module,
     /// # &ImportsBuilder::default()

--- a/src/module.rs
+++ b/src/module.rs
@@ -24,11 +24,11 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
+use casper_wasm::elements::{External, InitExpr, Instruction, Internal, ResizableLimits, Type};
 use core::{
     cell::{Ref, RefCell},
     fmt,
 };
-use parity_wasm::elements::{External, InitExpr, Instruction, Internal, ResizableLimits, Type};
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 
 /// Reference to a [`ModuleInstance`].

--- a/src/module.rs
+++ b/src/module.rs
@@ -612,8 +612,8 @@ impl ModuleInstance {
     /// #   r#"
     /// #   (module
     /// #       (func (export "add") (param i32 i32) (result i32)
-    /// #           get_local 0
-    /// #           get_local 1
+    /// #           local.get 0
+    /// #           local.get 1
     /// #           i32.add
     /// #       )
     /// #   )

--- a/src/prepare/compile.rs
+++ b/src/prepare/compile.rs
@@ -1,6 +1,6 @@
 use alloc::{string::String, vec::Vec};
 
-use parity_wasm::elements::{BlockType, FuncBody, Instruction};
+use casper_wasm::elements::{BlockType, FuncBody, Instruction};
 
 use crate::isa;
 use validation::{

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -1,6 +1,6 @@
 use crate::isa;
 use alloc::vec::Vec;
-use parity_wasm::elements::Module;
+use casper_wasm::elements::Module;
 use validation::{validate_module, Error, Validator};
 
 #[cfg(not(feature = "std"))]
@@ -61,7 +61,7 @@ pub fn compile_module(module: Module) -> Result<CompiledModule, Error> {
 ///   consumes or produces a value of a floating point type)
 /// - If a floating point type used in a definition of a function.
 pub fn deny_floating_point(module: &Module) -> Result<(), Error> {
-    use parity_wasm::elements::{
+    use casper_wasm::elements::{
         Instruction::{self, *},
         Type,
         ValueType,

--- a/src/prepare/tests.rs
+++ b/src/prepare/tests.rs
@@ -113,7 +113,7 @@ fn get_local() {
         r#"
 		(module
 			(func (export "call") (param i32) (result i32)
-				get_local 0
+				local.get 0
 			)
 		)
 	"#,
@@ -137,8 +137,8 @@ fn get_local_2() {
         r#"
 		(module
 			(func (export "call") (param i32) (param i32) (result i32)
-				get_local 0
-                get_local 1
+				local.get 0
+                local.get 1
                 drop
 			)
 		)
@@ -165,7 +165,7 @@ fn explicit_return() {
         r#"
 		(module
 			(func (export "call") (param i32) (result i32)
-				get_local 0
+				local.get 0
 				return
 			)
 		)
@@ -193,9 +193,9 @@ fn add_params() {
     let module = validate(
         r#"
 		(module
-			(func (export "call") (param i32) (param i32) (result i32)
-				get_local 0
-				get_local 1
+			(func (export "call") (param $param1 i32) (param $param2 i32) (result i32)
+				local.get $param1
+				local.get $param2
 				i32.add
 			)
 		)
@@ -228,8 +228,8 @@ fn drop_locals() {
 		(module
 			(func (export "call") (param i32)
 				(local i32)
-				get_local 0
-				set_local 1
+				local.get 0
+				local.set 1
 			)
 		)
 	"#,
@@ -300,10 +300,10 @@ fn if_else() {
 				i32.const 1
 				if
 					i32.const 2
-					set_local 0
+					local.set 0
 				else
 					i32.const 3
-					set_local 0
+					local.set 0
 				end
 			)
 		)
@@ -735,7 +735,7 @@ fn wabt_example() {
 		(module
 			(func (export "call") (param i32) (result i32)
 				block $exit
-					get_local 0
+					local.get 0
 					br_if $exit
 					i32.const 1
 					return

--- a/src/prepare/tests.rs
+++ b/src/prepare/tests.rs
@@ -6,7 +6,7 @@ use std::println;
 
 use super::{compile_module, CompiledModule};
 use crate::isa;
-use parity_wasm::{deserialize_buffer, elements::Module};
+use casper_wasm::{deserialize_buffer, elements::Module};
 
 fn validate(wat: &str) -> CompiledModule {
     let wasm = wat::parse_str(wat).unwrap();

--- a/src/pwasm.rs
+++ b/src/pwasm.rs
@@ -1,5 +1,5 @@
 use crate::ValueType;
-use parity_wasm::elements as pwasm;
+use casper_wasm::elements as pwasm;
 
 /// Compatibility trait to convert from and to `pwasm::ValueType`.
 pub trait PwasmCompat {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -23,8 +23,8 @@ use crate::{
     ValueType,
 };
 use alloc::{boxed::Box, vec::Vec};
+use casper_wasm::elements::Local;
 use core::{fmt, ops, u32, usize};
-use parity_wasm::elements::Local;
 use validation::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX};
 
 /// Maximum number of bytes on the value stack.

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,7 @@
 use crate::{func::FuncRef, module::check_limits, Error};
 use alloc::{rc::Rc, vec::Vec};
+use casper_wasm::elements::ResizableLimits;
 use core::{cell::RefCell, fmt, u32};
-use parity_wasm::elements::ResizableLimits;
 
 /// Reference to a table (See [`TableInstance`] for details).
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,7 +23,7 @@ impl Signature {
     /// # Examples
     ///
     /// ```rust
-    /// use wasmi::{Signature, ValueType};
+    /// use casper_wasmi::{Signature, ValueType};
     ///
     /// // s1: (i32) -> ()
     /// let s1 = Signature::new(&[ValueType::I32][..], None);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use crate::{pwasm::PwasmCompat, ValueType};
 use alloc::borrow::Cow;
-use parity_wasm::elements::{FunctionType, GlobalType, MemoryType, TableType};
+use casper_wasm::elements::{FunctionType, GlobalType, MemoryType, TableType};
 
 /// Signature of a [function].
 ///

--- a/tests/e2e/v0/host.rs
+++ b/tests/e2e/v0/host.rs
@@ -2,8 +2,7 @@
 extern crate std;
 
 use super::parse_wat;
-use std::println;
-use wasmi::{
+use casper_wasmi::{
     memory_units::Pages,
     Error,
     Externals,
@@ -28,6 +27,7 @@ use wasmi::{
     TrapCode,
     ValueType,
 };
+use std::println;
 
 #[derive(Debug, Clone, PartialEq)]
 struct HostErrorWithCode {

--- a/tests/e2e/v0/host.rs
+++ b/tests/e2e/v0/host.rs
@@ -514,7 +514,7 @@ fn recursion() {
 	(func (export "recursive") (param i64) (result i64)
 		;; return arg_0 + 42;
 		(i64.add
-			(get_local 0)
+			(local.get 0)
 			(i64.const 42)
 		)
 	)

--- a/tests/e2e/v0/mod.rs
+++ b/tests/e2e/v0/mod.rs
@@ -1,7 +1,7 @@
 mod host;
 mod wasm;
 
-use wasmi::{Error, Module};
+use casper_wasmi::{Error, Module};
 
 fn assert_send<T: Send>() {}
 fn assert_sync<T: Sync>() {}
@@ -23,7 +23,7 @@ fn assert_error_properties() {
 /// to a Value and back works as expected and the number remains unchanged.
 #[test]
 fn unsigned_to_value() {
-    use wasmi::RuntimeValue;
+    use casper_wasmi::RuntimeValue;
 
     let overflow_i32: u32 = ::core::i32::MAX as u32 + 1;
     assert_eq!(

--- a/tests/e2e/v0/wasm.rs
+++ b/tests/e2e/v0/wasm.rs
@@ -1,8 +1,7 @@
 // Test-only code importing std for no-std testing
 extern crate std;
 
-use std::{fs::File, vec::Vec};
-use wasmi::{
+use casper_wasmi::{
     memory_units::Pages,
     Error,
     FuncRef,
@@ -23,6 +22,7 @@ use wasmi::{
     TableInstance,
     TableRef,
 };
+use std::{fs::File, vec::Vec};
 
 struct Env {
     table_base: GlobalRef,

--- a/tests/e2e/wat/accumulate_u8.wast
+++ b/tests/e2e/wat/accumulate_u8.wast
@@ -28,48 +28,48 @@
   (block $label$0 (result i32)
    (if
     (i32.gt_s
-     (get_local $var$0)
+     (local.get $var$0)
      (i32.const 0)
     )
-    (block $label$1
-     (set_local $var$2
-      (i32.const 0)
-     )
-     (set_local $var$3
+    (then
+     (local.set $var$2
+     (i32.const 0)
+    )
+     (local.set $var$3
       (i32.const 0)
      )
     )
-    (block $label$2
+    (else
      (return
-      (i32.const 0)
+     (i32.const 0)
      )
     )
    )
    (loop $label$3
-    (set_local $var$3
+    (local.set $var$3
      (i32.add
       (i32.load8_u
        (i32.add
-        (get_local $var$1)
-        (get_local $var$2)
+        (local.get $var$1)
+        (local.get $var$2)
        )
       )
-      (get_local $var$3)
+      (local.get $var$3)
      )
     )
     (br_if $label$3
      (i32.ne
-      (tee_local $var$2
+      (local.tee $var$2
        (i32.add
-        (get_local $var$2)
+        (local.get $var$2)
         (i32.const 1)
        )
       )
-      (get_local $var$0)
+      (local.get $var$0)
      )
     )
    )
-   (get_local $var$3)
+   (local.get $var$3)
   )
  )
  (func $1 (type $1)
@@ -77,12 +77,12 @@
  )
  (func $2 (type $1)
   (block $label$0
-   (set_global $global$0
-    (get_global $import$0)
+   (global.set $global$0
+    (global.get $import$0)
    )
-   (set_global $global$1
+   (global.set $global$1
     (i32.add
-     (get_global $global$0)
+     (global.get $global$0)
      (i32.const 5242880)
     )
    )
@@ -91,4 +91,3 @@
  )
  ;; custom section "dylink", size 5
 )
-

--- a/tests/e2e/wat/inc_i32.wast
+++ b/tests/e2e/wat/inc_i32.wast
@@ -19,7 +19,7 @@
  (export "__post_instantiate" (func $2))
  (func $0 (type $0) (param $var$0 i32) (result i32)
   (i32.add
-   (get_local $var$0)
+   (local.get $var$0)
    (i32.const 1)
   )
  )
@@ -28,12 +28,12 @@
  )
  (func $2 (type $1)
   (block $label$0
-   (set_global $global$0
-    (get_global $import$0)
+   (global.set $global$0
+    (global.get $import$0)
    )
-   (set_global $global$1
+   (global.set $global$1
     (i32.add
-     (get_global $global$0)
+     (global.get $global$0)
      (i32.const 5242880)
     )
    )
@@ -42,4 +42,3 @@
  )
  ;; custom section "dylink", size 5
 )
-

--- a/tests/spec/v0/run.rs
+++ b/tests/spec/v0/run.rs
@@ -2,8 +2,7 @@
 
 use std::{collections::HashMap, fs::File};
 
-use wabt::script::{self, Action, Command, CommandKind, ScriptParser, Value as WabtValue};
-use wasmi::{
+use casper_wasmi::{
     memory_units::Pages,
     Error as InterpreterError,
     Externals,
@@ -29,6 +28,7 @@ use wasmi::{
     TableRef,
     Trap,
 };
+use wabt::script::{self, Action, Command, CommandKind, ScriptParser, Value as WabtValue};
 
 fn spec_to_value(val: WabtValue<u32, u64>) -> RuntimeValue {
     match val {

--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -1,7 +1,7 @@
 use super::{TestDescriptor, TestError, TestProfile, TestSpan};
 use anyhow::Result;
+use casper_wasmi::nan_preserving_float::{F32, F64};
 use std::collections::HashMap;
-use wasmi::nan_preserving_float::{F32, F64};
 use wasmi_core::Value;
 use wasmi_v1::{
     Config,

--- a/tests/spec_shim.rs
+++ b/tests/spec_shim.rs
@@ -1,7 +1,7 @@
 //! Official spec testsuite.
 
+extern crate casper_wasmi;
 extern crate wabt;
-extern crate wasmi;
 
 mod e2e;
 mod spec;

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -8,11 +8,11 @@ repository = "https://github.com/paritytech/wasmi"
 description = "Wasm code validator"
 
 [dependencies]
-parity-wasm = { version = "0.45.0", default-features = false }
+casper-wasm = { package = "parity-wasm", default-features = false, git = "https://github.com/casper-network/casper-wasm/", branch = "main" }
 
 [dev-dependencies]
 assert_matches = "1.1"
 
 [features]
 default = ["std"]
-std = ["parity-wasm/std"]
+std = ["casper-wasm/std"]

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
-repository = "https://github.com/paritytech/wasmi"
+repository = "https://github.com/casper-network/casper-wasmi"
 description = "Wasm code validator"
 
 [dependencies]
-casper-wasm = { package = "parity-wasm", default-features = false, git = "https://github.com/casper-network/casper-wasm/", branch = "main" }
+casper-wasm = { version = "0.46.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/validation/src/context.rs
+++ b/validation/src/context.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use alloc::vec::Vec;
-use parity_wasm::elements::{
+use casper_wasm::elements::{
     BlockType,
     FunctionType,
     GlobalType,

--- a/validation/src/func.rs
+++ b/validation/src/func.rs
@@ -8,8 +8,8 @@ use crate::{
     DEFAULT_TABLE_INDEX,
 };
 
+use casper_wasm::elements::{BlockType, Func, FuncBody, Instruction, TableElementType, ValueType};
 use core::u32;
-use parity_wasm::elements::{BlockType, Func, FuncBody, Instruction, TableElementType, ValueType};
 
 /// Maximum number of entries in value stack per function.
 const DEFAULT_VALUE_STACK_LIMIT: usize = 16384;
@@ -123,7 +123,7 @@ pub fn drive<T: FuncValidator>(
     }
 
     // The last `end` opcode should pop last instruction.
-    // parity-wasm ensures that there is always `End` opcode at
+    // casper-wasm ensures that there is always `End` opcode at
     // the end of the function body.
     assert!(context.frame_stack.is_empty());
 

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -22,7 +22,7 @@ use core::fmt;
 use std::error;
 
 use self::context::ModuleContextBuilder;
-use parity_wasm::elements::{
+use casper_wasm::elements::{
     BlockType,
     ExportEntry,
     External,

--- a/validation/src/tests.rs
+++ b/validation/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{Error, PlainValidator};
-use parity_wasm::{
+use casper_wasm::{
     builder::module,
     elements::{
         BlockType,

--- a/validation/src/util.rs
+++ b/validation/src/util.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use alloc::string::String;
-use parity_wasm::elements::{Local, ValueType};
+use casper_wasm::elements::{Local, ValueType};
 
 /// Locals are the concatenation of a slice of function parameters
 /// with function declared local variables.

--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin.freyler@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "../README.md"
-repository = "https://github.com/paritytech/wasmi"
-documentation = "https://paritytech.github.io/wasmi/"
+repository = "https://github.com/casper-network/casper-wasmi"
+documentation = "https://docs.rs/casper-wasmi/"
 description = "WebAssembly interpreter"
 keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 

--- a/wasmi_v1/src/module/tests.rs
+++ b/wasmi_v1/src/module/tests.rs
@@ -634,7 +634,7 @@ fn wabt_example() {
         (module
             (func (export "call") (param i32) (result i32)
                 block $exit
-                    get_local 0
+                    local.get 0
                     br_if $exit
                     i32.const 1
                     return


### PR DESCRIPTION
- Replace `parity-wasm` with `casper-wasm`
- Update README
- Fix some tests with old wast syntax (`set_local` -> `local.set`)