### PR TITLE
Update crate names for publishing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ criterion = "0.3.5"
 
 # Required as dev-dependency because otherwise benchmarks
 # have trouble using it without `cargo bench --all-features`.
-wasmi_v1 = { version = "0.11", path = "wasmi_v1" }
+wasmi_v1 = { path = "wasmi_v1" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
-wasmi_core = { version = "0.2.1", path = "core", default-features = false }
-validation = { package = "wasmi-validation", version = "0.5.0", path = "validation", default-features = false }
+casper-wasmi-core = { version = "0.2.1", path = "core", default-features = false }
+validation = { package = "casper-wasmi-validation", version = "0.5.0", path = "validation", default-features = false }
 casper-wasm = { version = "0.46.0", default-features = false }
 
 [dev-dependencies]
@@ -32,7 +32,7 @@ wasmi_v1 = { version = "0.11", path = "wasmi_v1" }
 default = ["std"]
 # Use `no-default-features` for a `no_std` build.
 std = [
-    "wasmi_core/std",
+    "casper-wasmi-core/std",
     "casper-wasm/std",
     "validation/std",
 ]
@@ -45,7 +45,7 @@ std = [
 #   based implementation.
 # - The default is to fall back is an inefficient vector based implementation.
 # - By nature this feature requires `region` and the Rust standard library.
-virtual_memory = ["wasmi_core/virtual_memory", "std"]
+virtual_memory = ["casper-wasmi-core/virtual_memory", "std"]
 
 reduced-stack-buffer = [ "casper-wasm/reduced-stack-buffer" ]
 
@@ -55,6 +55,7 @@ exclude = []
 
 [[bench]]
 name = "benches"
+path = "./benches/benches.rs"
 harness = false
 
 [profile.bench]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasmi_core"
+name = "casper-wasmi-core"
 version = "0.2.1"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/core/src/host_error.rs
+++ b/core/src/host_error.rs
@@ -14,7 +14,7 @@ use downcast_rs::{impl_downcast, DowncastSync};
 ///
 /// ```rust
 /// use std::fmt;
-/// use wasmi_core::{Trap, HostError};
+/// use casper_wasmi_core::{Trap, HostError};
 ///
 /// #[derive(Debug)]
 /// struct MyError {

--- a/src/host.rs
+++ b/src/host.rs
@@ -174,7 +174,7 @@ impl Externals for NopExternals {
 mod tests {
     use super::RuntimeArgs;
     use crate::RuntimeValue;
-    use wasmi_core::HostError;
+    use casper_wasmi_core::HostError;
 
     #[test]
     fn i32_runtime_args() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,8 +281,8 @@ pub use self::{
     types::{GlobalDescriptor, MemoryDescriptor, Signature, TableDescriptor},
 };
 #[doc(inline)]
-pub use wasmi_core::Value as RuntimeValue;
-pub use wasmi_core::{
+pub use casper_wasmi_core::Value as RuntimeValue;
+pub use casper_wasmi_core::{
     memory_units,
     FromValue,
     HostError,
@@ -294,7 +294,7 @@ pub use wasmi_core::{
 
 /// Mirrors the old value module.
 pub(crate) mod value {
-    pub use wasmi_core::{
+    pub use casper_wasmi_core::{
         ArithmeticOps,
         ExtendInto,
         Float,
@@ -311,7 +311,7 @@ pub(crate) mod value {
 
 /// Floating point types that preserve NaN values.
 pub mod nan_preserving_float {
-    pub use wasmi_core::{F32, F64};
+    pub use casper_wasmi_core::{F32, F64};
 }
 
 /// Deserialized module prepared for instantiation.

--- a/src/memory/mmap_bytebuf.rs
+++ b/src/memory/mmap_bytebuf.rs
@@ -5,7 +5,7 @@
 //! memory up to maximum. This might be a problem for systems that don't have a lot of virtual
 //! memory (i.e. 32-bit platforms).
 
-use wasmi_core::VirtualMemory;
+use casper_wasmi_core::VirtualMemory;
 
 /// A virtually allocated byte buffer.
 pub struct ByteBuf {

--- a/tests/e2e/v1/func.rs
+++ b/tests/e2e/v1/func.rs
@@ -1,7 +1,7 @@
 //! Tests for the `Func` type in `wasmi_v1`.
 
 use assert_matches::assert_matches;
-use wasmi_core::{Value, F32, F64};
+use casper_wasmi_core::{Value, F32, F64};
 use wasmi_v1::{errors::FuncError, Engine, Error, Func, Store};
 
 fn test_setup() -> Store<()> {

--- a/tests/spec/v1/context.rs
+++ b/tests/spec/v1/context.rs
@@ -1,8 +1,8 @@
 use super::{TestDescriptor, TestError, TestProfile, TestSpan};
 use anyhow::Result;
 use casper_wasmi::nan_preserving_float::{F32, F64};
+use casper_wasmi_core::Value;
 use std::collections::HashMap;
-use wasmi_core::Value;
 use wasmi_v1::{
     Config,
     Engine,

--- a/tests/spec/v1/run.rs
+++ b/tests/spec/v1/run.rs
@@ -1,6 +1,6 @@
 use super::{error::TestError, TestContext, TestDescriptor};
 use anyhow::Result;
-use wasmi_core::{Trap, Value, F32, F64};
+use casper_wasmi_core::{Trap, Value, F32, F64};
 use wasmi_v1::{Config, Error as WasmiError};
 use wast::{
     lexer::Lexer,

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasmi-validation"
+name = "casper-wasmi-validation"
 version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"

--- a/wasmi_v1/Cargo.toml
+++ b/wasmi_v1/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 
 [dependencies]
 wasmparser = { version = "0.83", package = "wasmparser-nostd", default-features = false }
-wasmi_core = { version = "0.2.1", path = "../core", default-features = false }
+casper-wasmi-core = { version = "0.2.1", path = "../core", default-features = false }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
 
 [dev-dependencies]
@@ -22,7 +22,7 @@ wat = "1"
 default = ["std"]
 # Use `no-default-features` for a `no_std` build.
 std = [
-    "wasmi_core/std",
+    "casper-wasmi-core/std",
     "wasmparser/std",
     "spin/std",
 ]
@@ -35,4 +35,4 @@ std = [
 #   based implementation.
 # - The default is to fall back is an inefficient vector based implementation.
 # - By nature this feature requires `region` and the Rust standard library.
-virtual_memory = ["wasmi_core/virtual_memory", "std"]
+virtual_memory = ["casper-wasmi-core/virtual_memory", "std"]

--- a/wasmi_v1/src/engine/bytecode/mod.rs
+++ b/wasmi_v1/src/engine/bytecode/mod.rs
@@ -6,7 +6,7 @@ mod utils;
 mod tests;
 
 pub use self::utils::{DropKeep, FuncIdx, GlobalIdx, LocalIdx, Offset, SignatureIdx, Target};
-use wasmi_core::UntypedValue;
+use casper_wasmi_core::UntypedValue;
 
 /// The internal `wasmi` bytecode that is stored for Wasm functions.
 ///

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -14,8 +14,14 @@ use crate::{
     core::{Trap, TrapCode, F32, F64},
     Func,
 };
+use casper_wasmi_core::{
+    memory_units::Pages,
+    ExtendInto,
+    LittleEndianConvert,
+    UntypedValue,
+    WrapInto,
+};
 use core::cmp;
-use wasmi_core::{memory_units::Pages, ExtendInto, LittleEndianConvert, UntypedValue, WrapInto};
 
 /// State that is used during Wasm function execution.
 #[derive(Debug)]

--- a/wasmi_v1/src/engine/func_args.rs
+++ b/wasmi_v1/src/engine/func_args.rs
@@ -1,5 +1,5 @@
+use casper_wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedValue};
 use core::cmp;
-use wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedValue};
 
 #[derive(Debug)]
 pub struct FuncParams<'a> {

--- a/wasmi_v1/src/engine/func_builder/locals_registry.rs
+++ b/wasmi_v1/src/engine/func_builder/locals_registry.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
+use casper_wasmi_core::ValueType;
 use core::cmp::Ordering;
-use wasmi_core::ValueType;
 
 /// A registry where local variables of a function are registered and resolved.
 ///

--- a/wasmi_v1/src/engine/func_builder/mod.rs
+++ b/wasmi_v1/src/engine/func_builder/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     ModuleError,
     Mutability,
 };
-use wasmi_core::{Value, ValueType, F32, F64};
+use casper_wasmi_core::{Value, ValueType, F32, F64};
 
 /// The interface to translate a `wasmi` bytecode function using Wasm bytecode.
 #[derive(Debug)]

--- a/wasmi_v1/src/engine/func_builder/value_stack.rs
+++ b/wasmi_v1/src/engine/func_builder/value_stack.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
+use casper_wasmi_core::ValueType;
 use core::cmp;
-use wasmi_core::ValueType;
 
 /// The value stack that is emulated during Wasm to `wasmi` bytecode translation.
 #[derive(Debug, Default)]

--- a/wasmi_v1/src/engine/func_types.rs
+++ b/wasmi_v1/src/engine/func_types.rs
@@ -1,4 +1,4 @@
-use wasmi_core::ValueType;
+use casper_wasmi_core::ValueType;
 
 use super::{EngineIdx, Guarded};
 use crate::{

--- a/wasmi_v1/src/engine/value_stack.rs
+++ b/wasmi_v1/src/engine/value_stack.rs
@@ -3,8 +3,8 @@
 use super::{DropKeep, DEFAULT_VALUE_STACK_LIMIT};
 use crate::core::TrapCode;
 use alloc::vec::Vec;
+use casper_wasmi_core::UntypedValue;
 use core::{fmt, fmt::Debug, iter, mem};
-use wasmi_core::UntypedValue;
 
 /// The value stack that is used to execute Wasm bytecode.
 ///

--- a/wasmi_v1/src/func/into_func.rs
+++ b/wasmi_v1/src/func/into_func.rs
@@ -8,8 +8,8 @@ use crate::{
     Caller,
     FuncType,
 };
+use casper_wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedValue};
 use core::{array, iter::FusedIterator};
-use wasmi_core::{DecodeUntypedSlice, EncodeUntypedSlice, UntypedValue};
 
 /// Closures and functions that can be used as host functions.
 pub trait IntoFunc<T, Params, Results>: Send + Sync + 'static {

--- a/wasmi_v1/src/func/typed_func.rs
+++ b/wasmi_v1/src/func/typed_func.rs
@@ -6,8 +6,8 @@ use crate::{
     AsContextMut,
     Error,
 };
+use casper_wasmi_core::Trap;
 use core::{fmt, fmt::Debug, marker::PhantomData};
-use wasmi_core::Trap;
 
 /// A typed [`Func`] instance.
 ///

--- a/wasmi_v1/src/lib.rs
+++ b/wasmi_v1/src/lib.rs
@@ -30,7 +30,7 @@ mod table;
 
 /// Definitions from the `wasmi_core` crate.
 #[doc(inline)]
-pub use wasmi_core as core;
+pub use casper_wasmi_core as core;
 
 /// Defines some errors that may occur upon interaction with `wasmi`.
 pub mod errors {

--- a/wasmi_v1/src/memory/buffer_vmem.rs
+++ b/wasmi_v1/src/memory/buffer_vmem.rs
@@ -1,7 +1,7 @@
 use super::{max_memory_len, MemoryError};
+use casper_wasmi_core::VirtualMemory;
+pub use casper_wasmi_core::VirtualMemoryError;
 use core::fmt::Debug;
-use wasmi_core::VirtualMemory;
-pub use wasmi_core::VirtualMemoryError;
 
 /// A virtual memory based byte buffer implementation.
 ///

--- a/wasmi_v1/src/memory/mod.rs
+++ b/wasmi_v1/src/memory/mod.rs
@@ -8,8 +8,8 @@ mod byte_buffer;
 
 use self::byte_buffer::{ByteBuffer, VirtualMemoryError};
 use super::{AsContext, AsContextMut, Index, StoreContext, StoreContextMut, Stored};
+use casper_wasmi_core::memory_units::{Bytes, Pages};
 use core::{fmt, fmt::Display};
-use wasmi_core::memory_units::{Bytes, Pages};
 
 /// A raw index to a linear memory entity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/wasmi_v1/src/module/init_expr.rs
+++ b/wasmi_v1/src/module/init_expr.rs
@@ -1,6 +1,6 @@
 use super::GlobalIdx;
 use crate::ModuleError;
-use wasmi_core::{Value, F32, F64};
+use casper_wasmi_core::{Value, F32, F64};
 
 /// An initializer expression.
 ///

--- a/wasmi_v1/src/module/instantiate/mod.rs
+++ b/wasmi_v1/src/module/instantiate/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     Memory,
     Table,
 };
-use wasmi_core::Value;
+use casper_wasmi_core::Value;
 
 impl Module {
     /// Instantiates a new [`Instance`] from the given compiled [`Module`].

--- a/wasmi_v1/src/module/utils.rs
+++ b/wasmi_v1/src/module/utils.rs
@@ -1,5 +1,5 @@
 use crate::{FuncType, GlobalType, MemoryType, ModuleError, Mutability, TableType};
-use wasmi_core::ValueType;
+use casper_wasmi_core::ValueType;
 
 impl TryFrom<wasmparser::TableType> for TableType {
     type Error = ModuleError;


### PR DESCRIPTION
With this PR `cargo publish` should work now for all versioned crates in workspace.