### PR TITLE
Implement call_indirect_overlong

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,34 +11,30 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
-      - name: Add extra targets
-        # Workaround for https://github.com/actions-rs/toolchain/issues/165
-        run: |
-          rustup target add thumbv7em-none-eabi
       - name: Build (default features)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: build
           args: --workspace
       - name: Build (all features)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: build
           args: --workspace --all-features
       - name: Build wasmi itself as no_std
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: build
           args: --workspace --lib --no-default-features --target thumbv7em-none-eabi --exclude wasmi_cli
       - name: Build (wasm32)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: build
           args: --workspace --no-default-features --target wasm32-unknown-unknown
@@ -47,9 +43,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        # windows-latest was pinned to windows-2019
-        # because of https://github.com/paritytech/wasmi/runs/5021520759
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest]
         include:
           # Include a new variable `rustc-args` with `-- --test-threads 1`
           # for windows-2019 to be used with virtual_memory crate feature
@@ -64,8 +58,8 @@ jobs:
         with:
           minimum-size: 6GB
           maximum-size: 32GB
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
@@ -73,14 +67,14 @@ jobs:
       - name: Checkout Submodules
         run: git submodule update --init --recursive
       - name: Test (default features)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         env:
           RUSTFLAGS: '--cfg debug_assertions'
         with:
           command: test
           args: --workspace --release
       - name: Test (all features)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         env:
           RUSTFLAGS: '--cfg debug_assertions'
           TEST_FLAGS: ${{ matrix.test-args }}
@@ -92,14 +86,14 @@ jobs:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           command: fmt
           args: --all -- --check
@@ -108,14 +102,14 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
           override: true
           components: rust-docs, rust-src
-      - uses: actions-rs/cargo@v1
+      - uses: dtolnay/rust-toolchain@stable
         env:
           RUSTDOCFLAGS: '-D warnings'
         with:
@@ -126,13 +120,13 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           command: audit
           args: ''
@@ -141,25 +135,25 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: clippy
       - name: Clippy (default features)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: clippy
           args: --workspace -- -D warnings
       - name: Clippy (all features)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: clippy
           args: --workspace --all-features -- -D warnings
       - name: Clippy (no_std)
-        uses: actions-rs/cargo@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           command: clippy
           args: --workspace --no-default-features -- -D warnings
@@ -169,11 +163,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,12 +44,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        include:
-          # Include a new variable `rustc-args` with `-- --test-threads 1`
-          # for windows-2019 to be used with virtual_memory crate feature
-          # enabled while testing.
-          - os: windows-2019
-            test-args: "--test-threads 1"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure Pagefile for Windows
@@ -157,33 +151,3 @@ jobs:
         with:
           command: clippy
           args: --workspace --no-default-features -- -D warnings
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          override: true
-      - name: Checkout Submodules
-        run: git submodule update --init --recursive
-      - name: Run cargo-tarpaulin (default features)
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.18.0'
-          args: --workspace
-#      - name: Upload to codecov.io
-#        uses: codecov/codecov-action@v1.0.2
-#        with:
-#          token: ${{secrets.CODECOV_TOKEN}}
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-wasmi"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>", "Nikolay Volf <nikvolf@gmail.com>", "Svyatoslav Nikolsky <svyatonik@yandex.ru>", "Sergey Pepyakin <s.pepyakin@gmail.com>", "Michał Papierski <michal@casperlabs.io>"]
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 [dependencies]
 casper-wasmi-core = { version = "0.3.0", path = "core", default-features = false }
 validation = { package = "casper-wasmi-validation", version = "0.6.0", path = "validation", default-features = false }
-casper-wasm = { git = "https://github.com/igor-casper/casper-wasm.git", branch = "core-78", default-features = false }
+casper-wasm = { version = "0.47.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 [dependencies]
 casper-wasmi-core = { version = "0.3.0", path = "core", default-features = false }
 validation = { package = "casper-wasmi-validation", version = "0.6.0", path = "validation", default-features = false }
-casper-wasm = { version = "0.46.0", default-features = false }
+casper-wasm = { git = "https://github.com/igor-casper/casper-wasm.git", branch = "core-78", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ reduced-stack-buffer = [ "casper-wasm/reduced-stack-buffer" ]
 
 sign_ext = ["casper-wasm/sign_ext", "validation/sign_ext" ]
 
+call_indirect_overlong = ["casper-wasm/call_indirect_overlong"]
+
 [workspace]
 members = ["validation", "core", "wasmi_v1", "cli"]
 exclude = []

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -146,7 +146,7 @@ struct Runtime<'a> {
 const SET_FUNC_INDEX: usize = 0;
 const GET_FUNC_INDEX: usize = 1;
 
-impl<'a> Externals for Runtime<'a> {
+impl Externals for Runtime<'_> {
     fn invoke_index(
         &mut self,
         index: usize,

--- a/src/func.rs
+++ b/src/func.rs
@@ -268,7 +268,7 @@ enum FuncInvocationKind<'args> {
     },
 }
 
-impl<'args> FuncInvocation<'args> {
+impl FuncInvocation<'_> {
     /// Whether this invocation is currently resumable.
     pub fn is_resumable(&self) -> bool {
         match &self.kind {

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,13 +13,13 @@ impl<'a> From<&'a [RuntimeValue]> for RuntimeArgs<'a> {
     }
 }
 
-impl<'a> AsRef<[RuntimeValue]> for RuntimeArgs<'a> {
+impl AsRef<[RuntimeValue]> for RuntimeArgs<'_> {
     fn as_ref(&self) -> &[RuntimeValue] {
         self.0
     }
 }
 
-impl<'a> RuntimeArgs<'a> {
+impl RuntimeArgs<'_> {
     /// Extract argument by index `idx`.
     ///
     /// # Errors

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -105,7 +105,7 @@ pub struct ImportsBuilder<'a> {
     modules: BTreeMap<String, &'a dyn ModuleImportResolver>,
 }
 
-impl<'a> Default for ImportsBuilder<'a> {
+impl Default for ImportsBuilder<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -146,7 +146,7 @@ impl<'a> ImportsBuilder<'a> {
     }
 }
 
-impl<'a> ImportResolver for ImportsBuilder<'a> {
+impl ImportResolver for ImportsBuilder<'_> {
     fn resolve_func(
         &self,
         module_name: &str,

--- a/src/isa.rs
+++ b/src/isa.rs
@@ -607,7 +607,7 @@ pub struct InstructionIter<'a> {
     position: u32,
 }
 
-impl<'a> InstructionIter<'a> {
+impl InstructionIter<'_> {
     #[inline]
     pub fn position(&self) -> u32 {
         self.position

--- a/src/isa.rs
+++ b/src/isa.rs
@@ -168,7 +168,7 @@ pub enum Instruction<'a> {
     Return(DropKeep),
 
     Call(u32),
-    CallIndirect(u32),
+    CallIndirect(u32, u32),
 
     Drop,
     Select,
@@ -376,7 +376,7 @@ pub(crate) enum InstructionInternal {
     Return(DropKeep),
 
     Call(u32),
-    CallIndirect(u32),
+    CallIndirect(u32, u32),
 
     Drop,
     Select,
@@ -643,7 +643,7 @@ impl<'a> Iterator for InstructionIter<'a> {
             InstructionInternal::Return(x) => Instruction::Return(x),
 
             InstructionInternal::Call(x) => Instruction::Call(x),
-            InstructionInternal::CallIndirect(x) => Instruction::CallIndirect(x),
+            InstructionInternal::CallIndirect(x, y) => Instruction::CallIndirect(x, y),
 
             InstructionInternal::Drop => Instruction::Drop,
             InstructionInternal::Select => Instruction::Select,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -536,7 +536,7 @@ impl MemoryInstance {
     /// [`clear`]: #method.set
     pub fn direct_access(&self) -> impl AsRef<[u8]> + '_ {
         struct Buffer<'a>(Ref<'a, ByteBuf>);
-        impl<'a> AsRef<[u8]> for Buffer<'a> {
+        impl AsRef<[u8]> for Buffer<'_> {
             fn as_ref(&self) -> &[u8] {
                 self.0.as_slice()
             }
@@ -557,7 +557,7 @@ impl MemoryInstance {
     /// [`copy`]: #method.copy
     pub fn direct_access_mut(&self) -> impl AsMut<[u8]> + '_ {
         struct Buffer<'a>(RefMut<'a, ByteBuf>);
-        impl<'a> AsMut<[u8]> for Buffer<'a> {
+        impl AsMut<[u8]> for Buffer<'_> {
             fn as_mut(&mut self) -> &mut [u8] {
                 self.0.as_slice_mut()
             }

--- a/src/module.rs
+++ b/src/module.rs
@@ -710,7 +710,7 @@ pub struct NotStartedModuleRef<'a> {
     instance: ModuleRef,
 }
 
-impl<'a> NotStartedModuleRef<'a> {
+impl NotStartedModuleRef<'_> {
     /// Returns not fully initialized instance.
     ///
     /// To fully initialize the instance you need to call either [`run_start`] or

--- a/src/prepare/compile.rs
+++ b/src/prepare/compile.rs
@@ -316,10 +316,10 @@ impl Compiler {
                 context.step(instruction)?;
                 self.sink.emit(isa::InstructionInternal::Call(*index));
             }
-            CallIndirect(index, _reserved) => {
+            CallIndirect(index, table) => {
                 context.step(instruction)?;
                 self.sink
-                    .emit(isa::InstructionInternal::CallIndirect(*index));
+                    .emit(isa::InstructionInternal::CallIndirect(*index, *table));
             }
 
             Drop => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -403,7 +403,9 @@ impl Interpreter {
             isa::Instruction::Return(drop_keep) => self.run_return(*drop_keep),
 
             isa::Instruction::Call(index) => self.run_call(context, *index),
-            isa::Instruction::CallIndirect(index, table) => self.run_call_indirect(context, *index, *table),
+            isa::Instruction::CallIndirect(index, table) => {
+                self.run_call_indirect(context, *index, *table)
+            }
 
             isa::Instruction::Drop => self.run_drop(),
             isa::Instruction::Select => self.run_select(),
@@ -816,9 +818,7 @@ impl Interpreter {
             .map_err(|_| TrapCode::MemoryAccessOutOfBounds)?;
         let stack_value: U = v.extend_into();
         self.value_stack
-            .push(stack_value.into())
-            .map_err(Into::into)
-            .map(|_| InstructionOutcome::RunNextInstruction)
+            .push(stack_value.into()).map(|_| InstructionOutcome::RunNextInstruction)
     }
 
     fn run_store<T>(
@@ -894,9 +894,7 @@ impl Interpreter {
 
     fn run_const(&mut self, val: RuntimeValue) -> Result<InstructionOutcome, TrapCode> {
         self.value_stack
-            .push(val.into())
-            .map_err(Into::into)
-            .map(|_| InstructionOutcome::RunNextInstruction)
+            .push(val.into()).map(|_| InstructionOutcome::RunNextInstruction)
     }
 
     fn run_relop<T, F>(&mut self, f: F) -> Result<InstructionOutcome, TrapCode>

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -694,7 +694,7 @@ impl Interpreter {
         let table = context
             .module()
             .table_by_index(DEFAULT_TABLE_INDEX)
-            .ok_or(TrapCode::Unreachable)?;
+            .ok_or(TrapCode::TableAccessOutOfBounds)?;
         let func_ref = table
             .get(table_func_idx)
             .map_err(|_| TrapCode::TableAccessOutOfBounds)?

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -818,7 +818,8 @@ impl Interpreter {
             .map_err(|_| TrapCode::MemoryAccessOutOfBounds)?;
         let stack_value: U = v.extend_into();
         self.value_stack
-            .push(stack_value.into()).map(|_| InstructionOutcome::RunNextInstruction)
+            .push(stack_value.into())
+            .map(|_| InstructionOutcome::RunNextInstruction)
     }
 
     fn run_store<T>(
@@ -894,7 +895,8 @@ impl Interpreter {
 
     fn run_const(&mut self, val: RuntimeValue) -> Result<InstructionOutcome, TrapCode> {
         self.value_stack
-            .push(val.into()).map(|_| InstructionOutcome::RunNextInstruction)
+            .push(val.into())
+            .map(|_| InstructionOutcome::RunNextInstruction)
     }
 
     fn run_relop<T, F>(&mut self, f: F) -> Result<InstructionOutcome, TrapCode>

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -403,7 +403,7 @@ impl Interpreter {
             isa::Instruction::Return(drop_keep) => self.run_return(*drop_keep),
 
             isa::Instruction::Call(index) => self.run_call(context, *index),
-            isa::Instruction::CallIndirect(index) => self.run_call_indirect(context, *index),
+            isa::Instruction::CallIndirect(index, table) => self.run_call_indirect(context, *index, *table),
 
             isa::Instruction::Drop => self.run_drop(),
             isa::Instruction::Select => self.run_select(),
@@ -680,25 +680,32 @@ impl Interpreter {
         &mut self,
         context: &mut FunctionContext,
         signature_idx: u32,
+        table_idx: u32,
     ) -> Result<InstructionOutcome, TrapCode> {
         let table_func_idx: u32 = self.value_stack.pop_as();
+        #[cfg(feature = "call_indirect_overlong")]
+        let table = context
+            .module()
+            .table_by_index(table_idx)
+            .ok_or(TrapCode::Unreachable)?;
+        #[cfg(not(feature = "call_indirect_overlong"))]
         let table = context
             .module()
             .table_by_index(DEFAULT_TABLE_INDEX)
-            .expect("Due to validation table should exists");
+            .ok_or(TrapCode::Unreachable)?;
         let func_ref = table
             .get(table_func_idx)
             .map_err(|_| TrapCode::TableAccessOutOfBounds)?
             .ok_or(TrapCode::ElemUninitialized)?;
 
         {
-            let actual_function_type = func_ref.signature();
-            let required_function_type = context
+            let actual_signature = func_ref.signature();
+            let expected_signature = context
                 .module()
                 .signature_by_index(signature_idx)
                 .expect("Due to validation type should exists");
 
-            if &*required_function_type != actual_function_type {
+            if &*expected_signature != actual_signature {
                 return Err(TrapCode::UnexpectedSignature);
             }
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -689,7 +689,7 @@ impl Interpreter {
         let table = context
             .module()
             .table_by_index(table_idx)
-            .ok_or(TrapCode::Unreachable)?;
+            .ok_or(TrapCode::TableAccessOutOfBounds)?;
         #[cfg(not(feature = "call_indirect_overlong"))]
         let table = context
             .module()

--- a/tests/e2e/v0/host.rs
+++ b/tests/e2e/v0/host.rs
@@ -597,7 +597,7 @@ fn defer_providing_externals() {
         acc: &'a mut u32,
     }
 
-    impl<'a> Externals for HostExternals<'a> {
+    impl Externals for HostExternals<'_> {
         fn invoke_index(
             &mut self,
             index: usize,

--- a/tests/spec/v0/mod.rs
+++ b/tests/spec/v0/mod.rs
@@ -20,6 +20,7 @@ macro_rules! run_proposal_test {
 
 run_test!("address", wasm_address);
 run_test!("align", wasm_align);
+#[cfg(not(feature = "call_indirect_overlong"))]
 run_test!("binary", wasm_binary);
 run_test!("block", wasm_block);
 run_test!("br", wasm_br);

--- a/tests/spec/v1/mod.rs
+++ b/tests/spec/v1/mod.rs
@@ -116,6 +116,7 @@ mod multi_value {
 define_spec_tests! {
     fn wasm_address("address");
     fn wasm_align("align");
+    #[cfg(not(feature = "call_indirect_overlong"))]
     fn wasm_binary("binary");
     fn wasm_binary_leb128("binary-leb128");
     fn wasm_block("block");

--- a/tests/spec/v1/run.rs
+++ b/tests/spec/v1/run.rs
@@ -315,8 +315,7 @@ fn execute_wast_execute(
     execute: WastExecute,
 ) -> Result<Vec<Value>, TestError> {
     match execute {
-        WastExecute::Invoke(invoke) => {
-            execute_wast_invoke(context, span, invoke)}
+        WastExecute::Invoke(invoke) => execute_wast_invoke(context, span, invoke),
         WastExecute::Wat(Wat::Module(module)) => {
             context.compile_and_instantiate(module).map(|_| Vec::new())
         }

--- a/tests/spec/v1/run.rs
+++ b/tests/spec/v1/run.rs
@@ -316,8 +316,7 @@ fn execute_wast_execute(
 ) -> Result<Vec<Value>, TestError> {
     match execute {
         WastExecute::Invoke(invoke) => {
-            execute_wast_invoke(context, span, invoke).map_err(Into::into)
-        }
+            execute_wast_invoke(context, span, invoke)}
         WastExecute::Wat(Wat::Module(module)) => {
             context.compile_and_instantiate(module).map(|_| Vec::new())
         }

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/casper-network/casper-wasmi"
 description = "Wasm code validator"
 
 [dependencies]
-casper-wasm = { version = "0.46.0", default-features = false }
+casper-wasm = { git = "https://github.com/igor-casper/casper-wasm.git", branch = "core-78", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -17,3 +17,4 @@ assert_matches = "1.1"
 default = ["std"]
 std = ["casper-wasm/std"]
 sign_ext = ["casper-wasm/sign_ext"]
+call_indirect_overlong = ["casper-wasm/call_indirect_overlong"]

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/casper-network/casper-wasmi"
 description = "Wasm code validator"
 
 [dependencies]
-casper-wasm = { git = "https://github.com/igor-casper/casper-wasm.git", branch = "core-78", default-features = false }
+casper-wasm = { version = "0.47.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/validation/src/func.rs
+++ b/validation/src/func.rs
@@ -1052,10 +1052,10 @@ impl<'a> FunctionValidationContext<'a> {
         Ok(())
     }
 
-    fn validate_call_indirect(&mut self, idx: u32, table: u32) -> Result<(), Error> {
+    fn validate_call_indirect(&mut self, idx: u32, _table: u32) -> Result<(), Error> {
         {
             #[cfg(feature = "call_indirect_overlong")]
-            let table = self.module.require_table(table)?;
+            let table = self.module.require_table(_table)?;
 
             #[cfg(not(feature = "call_indirect_overlong"))]
             let table = self.module.require_table(DEFAULT_TABLE_INDEX)?;

--- a/validation/src/func.rs
+++ b/validation/src/func.rs
@@ -289,8 +289,8 @@ impl<'a> FunctionValidationContext<'a> {
             Call(index) => {
                 self.validate_call(*index)?;
             }
-            CallIndirect(index, _reserved) => {
-                self.validate_call_indirect(*index)?;
+            CallIndirect(index, table) => {
+                self.validate_call_indirect(*index, *table)?;
             }
 
             Drop => {
@@ -1052,9 +1052,14 @@ impl<'a> FunctionValidationContext<'a> {
         Ok(())
     }
 
-    fn validate_call_indirect(&mut self, idx: u32) -> Result<(), Error> {
+    fn validate_call_indirect(&mut self, idx: u32, table: u32) -> Result<(), Error> {
         {
+            #[cfg(feature = "call_indirect_overlong")]
+            let table = self.module.require_table(table)?;
+
+            #[cfg(not(feature = "call_indirect_overlong"))]
             let table = self.module.require_table(DEFAULT_TABLE_INDEX)?;
+
             if table.elem_type() != TableElementType::AnyFunc {
                 return Err(Error(format!(
                     "Table {} has element type {:?} while `anyfunc` expected",

--- a/wasmi_v1/src/engine/bytecode/mod.rs
+++ b/wasmi_v1/src/engine/bytecode/mod.rs
@@ -5,6 +5,8 @@ mod utils;
 #[cfg(test)]
 mod tests;
 
+use crate::module::TableIdx;
+
 pub use self::utils::{DropKeep, FuncIdx, GlobalIdx, LocalIdx, Offset, SignatureIdx, Target};
 use casper_wasmi_core::UntypedValue;
 
@@ -37,7 +39,7 @@ pub enum Instruction {
     Unreachable,
     Return(DropKeep),
     Call(FuncIdx),
-    CallIndirect(SignatureIdx),
+    CallIndirect(SignatureIdx, TableIdx),
     Drop,
     Select,
     GetGlobal(GlobalIdx),

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -90,7 +90,7 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 Instr::Call(func) => {
                     return exec_ctx.visit_call(*func)
                 }
-                Instr::CallIndirect(signature)  => {
+                Instr::CallIndirect(signature, _table)  => {
                     return exec_ctx.visit_call_indirect(*signature)
                 }
                 Instr::Drop => { exec_ctx.visit_drop()?; }

--- a/wasmi_v1/src/engine/exec_context.rs
+++ b/wasmi_v1/src/engine/exec_context.rs
@@ -12,6 +12,7 @@ use super::{
 };
 use crate::{
     core::{Trap, TrapCode, F32, F64},
+    module::TableIdx,
     Func,
 };
 use casper_wasmi_core::{
@@ -90,8 +91,8 @@ impl<'engine, 'func> FunctionExecutor<'engine, 'func> {
                 Instr::Call(func) => {
                     return exec_ctx.visit_call(*func)
                 }
-                Instr::CallIndirect(signature, _table)  => {
-                    return exec_ctx.visit_call_indirect(*signature)
+                Instr::CallIndirect(signature, table)  => {
+                    return exec_ctx.visit_call_indirect(*signature, *table)
                 }
                 Instr::Drop => { exec_ctx.visit_drop()?; }
                 Instr::Select => { exec_ctx.visit_select()?; }
@@ -663,9 +664,17 @@ where
         self.call_func(func)
     }
 
-    fn visit_call_indirect(&mut self, signature_index: SignatureIdx) -> Result<CallOutcome, Trap> {
+    fn visit_call_indirect(
+        &mut self,
+        signature_index: SignatureIdx,
+        table_index: TableIdx,
+    ) -> Result<CallOutcome, Trap> {
         let func_index: u32 = self.value_stack.pop_as();
-        let table = self.default_table();
+        let table = self
+            .frame
+            .instance
+            .get_table(self.ctx.as_context(), table_index.into_u32())
+            .ok_or(TrapCode::Unreachable)?;
         let func = table
             .get(self.ctx.as_context(), func_index as usize)
             .map_err(|_| TrapCode::TableAccessOutOfBounds)?

--- a/wasmi_v1/src/engine/func_builder/mod.rs
+++ b/wasmi_v1/src/engine/func_builder/mod.rs
@@ -22,7 +22,7 @@ use self::{
 };
 use super::{DropKeep, FuncBody, Instruction, Target};
 use crate::{
-    engine::bytecode::Offset,
+    engine::bytecode::{Offset, SignatureIdx},
     module::{
         BlockType,
         FuncIdx,
@@ -640,20 +640,21 @@ impl<'engine, 'parser> FunctionBuilder<'engine, 'parser> {
     pub fn translate_call_indirect(
         &mut self,
         func_type_idx: FuncTypeIdx,
-        table_idx: TableIdx,
+        table_index: TableIdx,
     ) -> Result<(), ModuleError> {
         self.translate_if_reachable(|builder| {
-            /// The default Wasm MVP table index.
-            const DEFAULT_TABLE_INDEX: u32 = 0;
-            assert_eq!(table_idx.into_u32(), DEFAULT_TABLE_INDEX);
-            let func_type_offset = builder.value_stack.pop1();
-            debug_assert_eq!(func_type_offset, ValueType::I32);
+            let func_type_index = func_type_idx.into_u32().into();
+            let table = TableIdx::from(table_index);
+            builder.value_stack.pop1();
             let func_type = builder.func_type_at(func_type_idx);
             builder.adjust_value_stack_for_call(&func_type);
-            let func_type_idx = func_type_idx.into_u32().into();
             builder
                 .inst_builder
-                .push_inst(Instruction::CallIndirect(func_type_idx));
+                .push_inst(Instruction::CallIndirect(
+                    func_type_index,
+                    table
+                )
+            );
             Ok(())
         })
     }

--- a/wasmi_v1/src/engine/func_builder/mod.rs
+++ b/wasmi_v1/src/engine/func_builder/mod.rs
@@ -645,7 +645,8 @@ impl<'engine, 'parser> FunctionBuilder<'engine, 'parser> {
         self.translate_if_reachable(|builder| {
             let func_type_index = func_type_idx.into_u32().into();
             let table = TableIdx::from(table_index);
-            builder.value_stack.pop1();
+            let func_type_offset = builder.value_stack.pop1();
+            debug_assert_eq!(func_type_offset, ValueType::I32);
             let func_type = builder.func_type_at(func_type_idx);
             builder.adjust_value_stack_for_call(&func_type);
             builder

--- a/wasmi_v1/src/engine/func_builder/mod.rs
+++ b/wasmi_v1/src/engine/func_builder/mod.rs
@@ -650,11 +650,7 @@ impl<'engine, 'parser> FunctionBuilder<'engine, 'parser> {
             builder.adjust_value_stack_for_call(&func_type);
             builder
                 .inst_builder
-                .push_inst(Instruction::CallIndirect(
-                    func_type_index,
-                    table
-                )
-            );
+                .push_inst(Instruction::CallIndirect(func_type_index, table));
             Ok(())
         })
     }

--- a/wasmi_v1/src/module/export.rs
+++ b/wasmi_v1/src/module/export.rs
@@ -33,7 +33,7 @@ impl FuncIdx {
 /// The index of a table declaration within a [`Module`].
 ///
 /// [`Module`]: [`super::Module`]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TableIdx(pub(super) u32);
 
 impl TableIdx {


### PR DESCRIPTION
Implements the ``call_indirect_overlong`` feature that's a subset of the [reference-types proposal](https://github.com/WebAssembly/reference-types).

This is due to newer Rust toolchains emitting ``call_indirect`` tables, relying on this extended functionality. As of now, the Rust compiler only uses that small subset of the reference types proposal, and there are no known plans to expand the usage, so we should be fine supporting this alone. That being said, WASMs produced with other means can still use the entire feature set, which will fail given the current implementation.